### PR TITLE
Make usable for bundled python applications

### DIFF
--- a/src/winwifi/main.py
+++ b/src/winwifi/main.py
@@ -97,7 +97,7 @@ class WinWiFi:
     def netsh(cls, args: List[str], timeout: int = 3, check: bool = True) -> subprocess.CompletedProcess:
         return subprocess.run(
                 ['netsh'] + args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                timeout=timeout, check=check, encoding=sys.stdout.encoding)
+                timeout=timeout, check=check, encoding="UTF-8", shell = True)
 
     @classmethod
     def get_profiles(cls, callback: Callable = lambda x: None) -> List[str]:


### PR DESCRIPTION
-Stops winwifi scanning from making command line windows, which might be annoying for users using an application programmed in python -Sets encoding to UTF-8, allowing for bundled applications to run without command line window.