### PR TITLE
Fix encoding for multiple languages

### DIFF
--- a/src/winwifi/__main__.py
+++ b/src/winwifi/__main__.py
@@ -3,6 +3,7 @@ import pkg_resources
 import plumbum.cli
 import sys
 from typing import List
+from ctypes import windll
 
 from .main import WiFiConstant, WiFiInterface, WinWiFi
 
@@ -87,10 +88,13 @@ class WifiForget(plumbum.cli.Application):
 def main() -> int:
     if os.name == 'nt':
         os.system('chcp 65001 >nul 2>&1')
-    if sys.stdout.encoding != 'utf8':
-        sys.stdout.reconfigure(encoding='utf8')
-    if sys.stderr.encoding != 'utf8':
-        sys.stderr.reconfigure(encoding='utf8')
+        
+    system_encoding = str(windll.kernel32.GetConsoleOutputCP())
+        
+    if sys.stdout.encoding != system_encoding:
+        sys.stdout.reconfigure(encoding=system_encoding)
+    if sys.stderr.encoding != system_encoding:
+        sys.stderr.reconfigure(encoding=system_encoding)
 
     return Wifi.run()[1]
 


### PR DESCRIPTION
Error to fix:
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa0 in position 31: invalid start byte

Issue:
Although sys.stdout has been set to utf-8, subprocess still returns characters encoded according to the system code page. Therefore, the netsh command fails on systems with languages that have characters not supported by UTF-8, such as Portuguese.

Solution:
Using ctypes windll, the code page used by the system was determined, typically cp65001 or utf-8 for English and cp850 for multiple Latin languages, and sys.stdout encoding was configured accordingly.
